### PR TITLE
Feature: Hide paywalls for Admin users; Improve routing; Fix bug with Live Now card

### DIFF
--- a/api/src/resolvers/ChatEventResolver.ts
+++ b/api/src/resolvers/ChatEventResolver.ts
@@ -15,7 +15,7 @@ export class ChatEventResolver {
       order: {
         createdAt: 'DESC',
       },
-      take: 10,
+      take: 15,
     });
     const payments = await Payment.find({
       where: { payeeUserId: parentUserId },
@@ -23,7 +23,7 @@ export class ChatEventResolver {
       order: {
         createdAt: 'DESC',
       },
-      take: 10,
+      take: 15,
     });
 
     const chatsAndPayments = [...chats, ...payments];

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
 
 import useCurrentUser from 'hooks/useCurrentUser';
 
+import { Grid, Typography } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 
 import Header from 'components/Header';
@@ -17,16 +18,21 @@ import LinkStripeAccount from 'screens/LinkStripeAccount';
 import AutoLogin from 'screens/AutoLogin';
 import Admin from 'screens/Admin';
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles(({ spacing }) => ({
   content: {
     minHeight: 800,
+  },
+  networkError: {
+    marginTop: spacing(9),
+    padding: spacing(2),
+    textAlign: 'center',
   },
 }));
 
 function App() {
   const classes = useStyles();
 
-  const [currentUser] = useCurrentUser();
+  const [currentUser, { loading, data, error }] = useCurrentUser();
 
   useEffect(() => {
     // Remove any styles left over from server side rendering
@@ -36,7 +42,23 @@ function App() {
     }
   }, []);
 
-  const currentUserUrlSlug = currentUser?.urlSlug;
+  const isCheckingForCurrentUser = !data && loading;
+  if (isCheckingForCurrentUser) {
+    return null;
+  } else if (error) {
+    return (
+      <Grid
+        container
+        direction="column"
+        alignItems="center"
+        className={classes.networkError}
+      >
+        <Typography color="error">
+          Network error - please check your internet and refresh the page
+        </Typography>
+      </Grid>
+    );
+  }
 
   return (
     <Router>
@@ -60,22 +82,24 @@ function App() {
             <Admin />
           </Route>
 
-          <Route path={`/${currentUserUrlSlug}`}>
-            <Switch>
-              <Route exact path="/:currentUserUrlSlug/edit-profile">
-                <EditProfile />
-              </Route>
-              <Route exact path="/:currentUserUrlSlug/edit-shows">
-                <EditShows />
-              </Route>
-              <Route exact path="/:currentUserUrlSlug/payments">
-                <Payments />
-              </Route>
-              <Route>
-                <Dashboard />
-              </Route>
-            </Switch>
-          </Route>
+          {currentUser && (
+            <Route path={`/${currentUser.urlSlug}`}>
+              <Switch>
+                <Route exact path="/:currentUserUrlSlug/edit-profile">
+                  <EditProfile />
+                </Route>
+                <Route exact path="/:currentUserUrlSlug/edit-shows">
+                  <EditShows />
+                </Route>
+                <Route exact path="/:currentUserUrlSlug/payments">
+                  <Payments />
+                </Route>
+                <Route>
+                  <Dashboard />
+                </Route>
+              </Switch>
+            </Route>
+          )}
 
           <Route path="/:userUrlSlug">
             <Watch />

--- a/web/src/components/LiveNowCard.tsx
+++ b/web/src/components/LiveNowCard.tsx
@@ -6,7 +6,7 @@ import { grey } from '@material-ui/core/colors';
 
 import { User, Show } from 'types';
 
-const useStyles = makeStyles(({ palette, spacing }) => ({
+const useStyles = makeStyles(({ spacing }) => ({
   cardLink: {
     textDecoration: 'none',
   },
@@ -24,11 +24,12 @@ const useStyles = makeStyles(({ palette, spacing }) => ({
   },
   image: {
     height: 72,
-    marginRight: 10,
+    marginRight: spacing(1),
     minWidth: 109,
   },
   textContent: {
     height: 72,
+    marginLeft: spacing(1),
     overflow: 'hidden',
   },
 }));
@@ -45,7 +46,9 @@ const LiveNowCard = ({ user, show }: LiveNowCardProps) => {
     <>
       <Link to={user.urlSlug} className={classes.cardLink}>
         <Card className={classes.card} elevation={3}>
-          <CardMedia image={user.profileImageUrl} className={classes.image} />
+          {user.profileImageUrl && (
+            <CardMedia image={user.profileImageUrl} className={classes.image} />
+          )}
           <Grid className={classes.textContent}>
             {show && <Typography variant="body1">{show.title}</Typography>}
             <Typography variant="body1" color="textSecondary">

--- a/web/src/components/LiveVideoArea.tsx
+++ b/web/src/components/LiveVideoArea.tsx
@@ -93,6 +93,7 @@ const LiveVideoArea = ({ show, payee }: LiveVideoAreaProps) => {
     userUrlSlug: payee?.urlSlug,
   });
   const hasAccessToLiveVideo = UserService.hasAccessToLiveVideo({
+    user: currentUser,
     paymentForShow,
     recentPaymentsToPayee,
   });

--- a/web/src/screens/Watch.tsx
+++ b/web/src/screens/Watch.tsx
@@ -9,6 +9,7 @@ import {
 } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 
+import useCurrentUser from 'hooks/useCurrentUser';
 import useUser from 'hooks/useUser';
 import useShowsForUser from 'hooks/useShowsForUser';
 import useFreePreview from 'hooks/useFreePreview';
@@ -98,6 +99,7 @@ const Watch = () => {
   const { pathname } = useLocation();
   const urlSlug = pathname.split('/')[1];
 
+  const [currentUser] = useCurrentUser();
   const [user, userQuery] = useUser({ urlSlug, subscribe: true });
   const { freePreviewIsUsed } = useFreePreview({
     userUrlSlug: urlSlug,
@@ -135,6 +137,7 @@ const Watch = () => {
     const shouldShowLiveVideo =
       user.isInPublicMode && user.muxLiveStreamStatus === 'active';
     const hasAccessToLiveVideo = User.hasAccessToLiveVideo({
+      user: currentUser,
       paymentForShow,
       recentPaymentsToPayee,
     });
@@ -148,6 +151,7 @@ const Watch = () => {
     }
   }, [
     user,
+    currentUser,
     freePreviewIsUsed,
     paymentForShow,
     recentPaymentsToPayee,

--- a/web/src/services/Show.ts
+++ b/web/src/services/Show.ts
@@ -35,7 +35,18 @@ const generateLiveNowData = (
   return usersStreamingLive.map((user) => {
     const showsByUser = filterShowsByUser(shows, user.id);
     const activeShow = getActiveShow(showsByUser);
-    const activeShowStartsSoon = DateTime.showtimeIsSoon(activeShow?.showtime);
+    if (!activeShow) {
+      return {
+        user,
+        show: undefined,
+      };
+    }
+    const activeShowAlreadyStarted =
+      new Date(activeShow.showtime) <= new Date();
+    if (activeShowAlreadyStarted) {
+      return { user, show: activeShow };
+    }
+    const activeShowStartsSoon = DateTime.showtimeIsSoon(activeShow.showtime);
     return {
       user,
       show: activeShowStartsSoon ? activeShow : undefined,

--- a/web/src/services/User.ts
+++ b/web/src/services/User.ts
@@ -2,15 +2,21 @@ import { User, UserPermission } from 'types';
 import { PaymentForShow, RecentPaymentToPayee } from 'hooks/usePayments';
 
 interface HasAccessToLiveVideoArgs {
+  user?: User;
   paymentForShow?: PaymentForShow;
   recentPaymentsToPayee?: RecentPaymentToPayee[];
 }
 
 const hasAccessToLiveVideo = ({
+  user,
   paymentForShow,
   recentPaymentsToPayee,
 }: HasAccessToLiveVideoArgs) => {
-  if (Boolean(paymentForShow) || Boolean(recentPaymentsToPayee?.length)) {
+  if (
+    Boolean(isAdmin(user)) ||
+    Boolean(paymentForShow) ||
+    Boolean(recentPaymentsToPayee?.length)
+  ) {
     return true;
   }
   return false;


### PR DESCRIPTION
<!-- Feature/Improvement/Fix: PR Title -->

**Linked issue:**

Fixes #24 
Fixes #22 
Fixes #23 (at least improves it, we can see if anyone requests ability to explicitly load older chats)

**What does this PR change or add to the repo?**

- Don't show paywalls for Admin users
- Fix display of show title on `LiveNowCard` for a show that recently started
- Load 30 chat events by default instead of 20
- Improve routing
  - Make a top level request for current user, so that any future requests from the component tree will be cached
  - Only show `currentUser` routes if there is in fact a `currentUser`

**How to try this PR?**

- Run app locally
- Try broadcasting to a show just after showtime, you should see a title on the `LiveNowCard`
- Try watching as an Admin user

**Screenshot:**

**Reviewer checklist:**

- [ ] Did you manually test the functionality?
- [ ] Does this PR improve the codebase?
