### PR TITLE
[Improvement]: Add certbot challenge path to Nginx config

### DIFF
--- a/.github/release_template.md
+++ b/.github/release_template.md
@@ -1,4 +1,4 @@
-<!-- [Release]: Title -->
+<!-- vX.x.x -->
 
 Any introductory notes about this release...
 

--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -2,6 +2,10 @@ server {
   listen 80 default_server;
   listen [::]:80 default_server;
 
+  location /.well-known {
+    root /var/www/html/;
+  }
+
   return 301 https://$host$request_uri;
 }
 


### PR DESCRIPTION
<!-- [Feature/Improvement/Fix]: PR Title -->

**Linked issue:**

n/a

**What does this PR change or add to the repo?**

- In order to allow auto-renewing of certs, this exposes the `/.well-known` route on the running server and points towards where certbot will create the challenge files

**How to try this PR?**

**Screenshot:**

**Reviewer checklist:**

- [ ] Did you manually test the functionality?
- [ ] Does this PR improve the codebase?
